### PR TITLE
Decrease the voting time to 48 hours

### DIFF
--- a/Scripts/robot.py
+++ b/Scripts/robot.py
@@ -64,8 +64,8 @@ class Robot:
                             elapsedTime = (datetime.datetime.now() - timeOpened).total_seconds()
                             
                             
-                            seventyTwoHoursInSeconds = 259200
-                            if elapsedTime < seventyTwoHoursInSeconds:
+                            fourtyEightHoursInSeconds = 172800
+                            if elapsedTime < fourtyEightHoursInSeconds:
                                 print "not enough time has passed to merge the pull request"
                             else:
                                 if upVotes > downVotes:
@@ -78,7 +78,7 @@ class Robot:
                                     prAsIssue.edit(state='closed')
                     
                     if not robotHasAlreadyCommented:
-                        commentText = "Congratulations on the pull request @" + pullRequest.user.login + "!!\n\n Now we need to decide as a community if we want to integrate these changes. You can vote by giving this comment a thumbs up or a thumbs down. Votes are counted in 72 hours. Ties will not be merged.\n\nI'm just a silly robot, but I love to see people contributing so I'm going vote thumbs up!"
+                        commentText = "Congratulations on the pull request @" + pullRequest.user.login + "!!\n\n Now we need to decide as a community if we want to integrate these changes. You can vote by giving this comment a thumbs up or a thumbs down. Votes are counted in 48 hours. Ties will not be merged.\n\nI'm just a silly robot, but I love to see people contributing so I'm going vote thumbs up!"
                         theNewComment = prAsIssue.create_comment(commentText)
                         theNewComment.create_reaction("+1")
                 


### PR DESCRIPTION
72 hours is too long. We've started using the robot in the Maslow repositories so that we can get some experience about if it is useful and one of the first things I've learned is that 72 hours is way to long to wait to merge something. 48 seems like a better amount of time. It's long enough to allow for everyone interested to weigh in, but no so long that the project is held back by waiting for PRs to merge