### PR TITLE
Remove the word beta from the website header

### DIFF
--- a/generateHTML.py
+++ b/generateHTML.py
@@ -130,7 +130,7 @@ class GenerateHTML:
                 with tag('section', klass="content"):
                     
                     with tag('p', klass = 'title'):
-                        text('Beta! - A place for community driven open source projects to live - Beta!')
+                        text('A place for community driven open source projects to live')
                     
                     #Generate a grid of tracked projects
                     


### PR DESCRIPTION
We've been using it for a while now and while there are still bugs, I think we can take out the word beta