### PR TITLE
Remove yattag module from website builder

### DIFF
--- a/Scripts/gardenRobot.py
+++ b/Scripts/gardenRobot.py
@@ -18,7 +18,7 @@ repos = org.get_repos()
 robot = Robot()
 
 weShouldCheckImageLinks = False
-if random.randint(0, 10) == 1:
+if random.randint(0, 20) == 1:
     weShouldCheckImageLinks = True
 
 for repo in repos:

--- a/Scripts/robot.py
+++ b/Scripts/robot.py
@@ -28,17 +28,13 @@ class Robot:
             
             projectIsCommunityManaged = False
             
-            print repo.full_name
-            
             try:
                 data = json.loads(robotText)
                 if data["ModerationLevel"] == 'communityManaged':
                     projectIsCommunityManaged = True
-                    print "community managed by json"
             except:
                 if 'communityManaged' in robotText:
                     projectIsCommunityManaged = True
-                    print "community managed by old method"
             
             #if the project is community managed we need to see if there are pull requests to merge
             if projectIsCommunityManaged:
@@ -53,12 +49,6 @@ class Robot:
                     print "\n\n"+pullRequest.title
                     
                     pullRequestAlreadyRespondedTo = False
-                    
-                    #print "mergable " + str(pullRequest.mergeable)
-                    #print pullRequest.user
-                    #print "comments:" + str(pullRequest.comments)
-                    #print "review comments:" + str(pullRequest.review_comments)
-                    
                     
                     prAsIssue = repo.get_issue(pullRequest.number)
                     comments  = prAsIssue.get_comments()  #this is a work around for a bug in pygithub. We have to use the issues API :rolleyes:

--- a/Scripts/robot.py
+++ b/Scripts/robot.py
@@ -28,11 +28,11 @@ class Robot:
             
             projectIsCommunityManaged = False
             
-            try:
+            try:                                                        #Try to read the robot.md file as a json file
                 data = json.loads(robotText)
                 if data["ModerationLevel"] == 'communityManaged':
                     projectIsCommunityManaged = True
-            except:
+            except:                                                     #If it's not a json file fall back to the old technique
                 if 'communityManaged' in robotText:
                     projectIsCommunityManaged = True
             

--- a/Scripts/robot.py
+++ b/Scripts/robot.py
@@ -3,6 +3,7 @@ import          urllib2
 import          datetime
 import          pygit2
 import          base64
+import          json
 
 class Robot:
     
@@ -25,7 +26,22 @@ class Robot:
             text        = urllib2.urlopen(robotURL)
             robotText   = text.read()
             
-            if 'communityManaged' in robotText:                
+            projectIsCommunityManaged = False
+            
+            print repo.full_name
+            
+            try:
+                data = json.loads(robotText)
+                if data["ModerationLevel"] == 'communityManaged':
+                    projectIsCommunityManaged = True
+                    print "community managed by json"
+            except:
+                if 'communityManaged' in robotText:
+                    projectIsCommunityManaged = True
+                    print "community managed by old method"
+            
+            #if the project is community managed we need to see if there are pull requests to merge
+            if projectIsCommunityManaged:
                 '''
                 
                 Check if there are any open pull requests that need to be voted on

--- a/createRepo.py
+++ b/createRepo.py
@@ -1,7 +1,7 @@
-from github import Github
-import pygit2
-import os
-import time
+from github import  Github
+import              pygit2
+import              os
+import              time
 
 file = open("/var/www/html/uploads/usrinput.txt", "r")
 userInputsText = file.read() 
@@ -52,8 +52,11 @@ if projectName != "none":
             print "Unable to add " + githubUser + " as a collaborator:"
             print e
         
-        robotText = "ModerationLevel = " + managementStyle + "\n\n Facilitator: " + githubUser + "\n"
-        
+        robotText = (
+            '{\n'
+                '"ModerationLevel": "' + managementStyle + '",\n'
+                '"Facilitator": "' + githubUser + '"\n'
+            '}')
         
         #create the markdown files
         repo.create_file("/README.md", "init commit", readmeText)

--- a/generateHTML.py
+++ b/generateHTML.py
@@ -102,32 +102,26 @@ class GenerateHTML:
         doc, tag, text = Doc().tagtext()
         
         with tag('html'):
-            with tag('head'):
-                doc.stag('link',rel='stylesheet', href='styles.css')
-                doc.stag('link',rel='stylesheet', type="text/css", href="https://fonts.googleapis.com/css?family=Open+Sans")
-                
+            doc.asis(
+                "<head>"
+                    "<link href='styles.css' rel='stylesheet' />"
+                    "<link href='https://fonts.googleapis.com/css?family=Open+Sans' type='text/css' rel='stylesheet' />"
+                "</head>")
             with tag('body', klass = 'body'):
-            
-                with tag('header', klass = 'header'):
                 
-                    with tag('div', klass = 'inner-header'):
-            
-                        with tag('a', href = 'index.html', klass='header-logo'):
-                        
-                            doc.stag('img', src="logo.png", width="auto", height="90")
-                        
-                        with tag('nav', klass = 'navigation'):
-                        
-                            with tag('a', href="howdoesthegardenwork.html", klass="button"):
-                                text('How does the garden work?')
-                            
-                            with tag('a', href="addaproject.html", klass="button"):
-                                text('Add a project')
-                                
-                            with tag('a', href="index.html", klass="button"):
-                                text('Browse projects')
-                        with tag('p', klass = "description"):
-                            text('A place for community driven open source projects to live')
+                doc.asis(
+                    "<header class = 'header'>"
+                        "<div class='inner-header'>"
+                            "<a href='index.html'>"
+                                "<img src='logo.png' style='width:auto;height:90px;border:0;'>"
+                            "</a>"
+                            "<nav class='navigation'>"
+                                "<a href='howdoesthegardenwork.html' class='nav-link button one-col'>How Does the Garden Work?</a>"
+                                "<a href='addaproject.html' class='nav-link button one-col'>Add A Project</a>"
+                                "<a href='index.html#projectsSection' class='nav-link button one-col'>Browse Projects</a>"
+                            "</nav>"
+                        "<p class = 'description'>"
+                            "A place for community driven open source projects to live")
                 
                 with tag('section', klass="content"):
                     
@@ -140,28 +134,35 @@ class GenerateHTML:
                         
                         
                         #this creates a boxed representation of the project
-                        with tag('a', href=project.projectFile, klass = "project_link"):
-                            with tag('div', klass = 'boxed'):
+                        
+                        projectSection = ("<a href= " + project.projectFile + " class = project_link>"
+                                            "<div class = boxed>"
+                                                "<div class = project-thumbnail>"
+                                                    "<img src="+project.mainPicture+" class = project_img>")
                                 
-                                with tag ('div', klass = 'project-thumbnail'):
-                                    doc.stag('img', src= project.mainPicture, klass = "project_img")                                    
-                                
-                                numberOfLinesProcessed = 0
-                                maxNumberToProcess = 3
-                                linesInReadme = project.READMEtext.split('\n', 5)
-                                
-                                for line in linesInReadme:
-                                    if len(line) > 0:
-                                        if line[0] is '#':
-                                            with tag('h1', klass = "boxed_text"):
-                                                text(line[1:])
-                                                project.projectName = line[1:]
-                                        elif line[0] is not '!':
-                                            with tag('p', klass = "boxed_text"):
-                                                text(line)
-                                    numberOfLinesProcessed = numberOfLinesProcessed + 1
-                                    if numberOfLinesProcessed > maxNumberToProcess:
-                                        break
+                        numberOfLinesProcessed = 0
+                        maxNumberToProcess = 3
+                        linesInReadme = project.READMEtext.split('\n', 5)
+                        
+                        for line in linesInReadme:
+                            if len(line) > 0:
+                                if line[0] is '#':
+                                    projectSection = projectSection + (
+                                    "<h1 class = boxed_text>"
+                                        +line[1:]+
+                                    "</h1>")
+                                    
+                                    project.projectName = line[1:]
+                                elif line[0] is not '!':
+                                    projectSection = projectSection + (
+                                    "<p class = boxed_text>"
+                                        +line+
+                                    "</p>")
+                            numberOfLinesProcessed = numberOfLinesProcessed + 1
+                            if numberOfLinesProcessed > maxNumberToProcess:
+                                break
+                        projectSection = projectSection + "</div> </div>"
+                        doc.asis(projectSection)
                 with tag('script'):
                     doc.asis("function truncate( n, useWordBoundary ){"
                             "if (this.length <= n) { return this; }"

--- a/generateHTML.py
+++ b/generateHTML.py
@@ -1,4 +1,3 @@
-from yattag import  Doc
 import              urllib2  # the lib that handles the url stuff
 import              random
 from markdown2      import Markdown
@@ -98,94 +97,94 @@ class GenerateHTML:
         
         '''
         
-        #generate the HTML for the site
-        doc, tag, text = Doc().tagtext()
+        #generate the HTML for the main page
         
-        with tag('html'):
-            doc.asis(
-                "<head>"
-                    "<link href='styles.css' rel='stylesheet' />"
-                    "<link href='https://fonts.googleapis.com/css?family=Open+Sans' type='text/css' rel='stylesheet' />"
-                "</head>")
-            with tag('body', klass = 'body'):
-                
-                doc.asis(
-                    "<header class = 'header'>"
-                        "<div class='inner-header'>"
-                            "<a href='index.html'>"
-                                "<img src='logo.png' style='width:auto;height:90px;border:0;'>"
-                            "</a>"
-                            "<nav class='navigation'>"
-                                "<a href='howdoesthegardenwork.html' class='nav-link button one-col'>How Does the Garden Work?</a>"
-                                "<a href='addaproject.html' class='nav-link button one-col'>Add A Project</a>"
-                                "<a href='index.html#projectsSection' class='nav-link button one-col'>Browse Projects</a>"
-                            "</nav>"
-                        "<p class = 'description'>"
-                            "A place for community driven open source projects to live")
-                
-                with tag('section', klass="content"):
+        pageHTML = ("<!DOCTYPE html>"
+                "<html>"
+                    "<head>"
+                        "<link href='styles.css' rel='stylesheet' />"
+                        "<link href='https://fonts.googleapis.com/css?family=Open+Sans' type='text/css' rel='stylesheet' />"
+                    "</head>"
+                    "<body class = body>"
+                        "<header class = 'header'>"
+                            "<div class='inner-header'>"
+                                "<a href='index.html'>"
+                                    "<img src='logo.png' style='width:auto;height:90px;border:0;'>"
+                                "</a>"
+                                "<nav class='navigation'>"
+                                    "<a href='howdoesthegardenwork.html' class='nav-link button one-col'>How Does the Garden Work?</a>"
+                                    "<a href='addaproject.html' class='nav-link button one-col'>Add A Project</a>"
+                                    "<a href='index.html#projectsSection' class='nav-link button one-col'>Browse Projects</a>"
+                                "</nav>"
+                                "<p class = 'description'>"
+                                    "A place for community driven open source projects to live"
+                                "</p>"
+                            "</div>"
+                        "</header>"
+                        "<section class = content>")
                     
                     #Generate a grid of tracked projects
                     
-                    for project in self.projects:
+        for project in self.projects:
+            print "Generating grid entry for: "
+            print project.projectName
+            
+            
+            #this creates a boxed representation of the project
+            
+            projectSection = ("<a href= " + project.projectFile + " class = project_link>"
+                                "<div class = boxed>"
+                                    "<div class = project-thumbnail>"
+                                        "<img src="+project.mainPicture+" class = project_img>")
+                    
+            numberOfLinesProcessed = 0
+            maxNumberToProcess = 3
+            linesInReadme = project.READMEtext.split('\n', 5)
+            
+            for line in linesInReadme:
+                if len(line) > 0:
+                    if line[0] is '#':
+                        projectSection = projectSection + (
+                        "<h1 class = boxed_text>"
+                            +line[1:]+
+                        "</h1>")
                         
-                        print "Generating grid entry for: "
-                        print project.projectName
-                        
-                        
-                        #this creates a boxed representation of the project
-                        
-                        projectSection = ("<a href= " + project.projectFile + " class = project_link>"
-                                            "<div class = boxed>"
-                                                "<div class = project-thumbnail>"
-                                                    "<img src="+project.mainPicture+" class = project_img>")
-                                
-                        numberOfLinesProcessed = 0
-                        maxNumberToProcess = 3
-                        linesInReadme = project.READMEtext.split('\n', 5)
-                        
-                        for line in linesInReadme:
-                            if len(line) > 0:
-                                if line[0] is '#':
-                                    projectSection = projectSection + (
-                                    "<h1 class = boxed_text>"
-                                        +line[1:]+
-                                    "</h1>")
-                                    
-                                    project.projectName = line[1:]
-                                elif line[0] is not '!':
-                                    projectSection = projectSection + (
-                                    "<p class = boxed_text>"
-                                        +line+
-                                    "</p>")
-                            numberOfLinesProcessed = numberOfLinesProcessed + 1
-                            if numberOfLinesProcessed > maxNumberToProcess:
-                                break
-                        projectSection = projectSection + "</div> </div>"
-                        doc.asis(projectSection)
-                with tag('script'):
-                    doc.asis("function truncate( n, useWordBoundary ){"
-                            "if (this.length <= n) { return this; }"
-                            "var subString = this.substr(0, n-1);"
-                            "return (useWordBoundary "
-                            "   ? subString.substr(0, subString.lastIndexOf(' ')) "
-                            "   : subString) + '&hellip;';"
-                        "};"
+                        project.projectName = line[1:]
+                    elif line[0] is not '!':
+                        projectSection = projectSection + (
+                        "<p class = boxed_text>"
+                            +line+
+                        "</p>")
+                numberOfLinesProcessed = numberOfLinesProcessed + 1
+                if numberOfLinesProcessed > maxNumberToProcess:
+                    break
+            projectSection = projectSection + "</div> </div>"
+            pageHTML = pageHTML + projectSection
+    
+        pageHTML = pageHTML + (
+        "<script>"
+            "function truncate( n, useWordBoundary ){"
+                "if (this.length <= n) { return this; }"
+                "var subString = this.substr(0, n-1);"
+                "return (useWordBoundary "
+                "   ? subString.substr(0, subString.lastIndexOf(' ')) "
+                "   : subString) + '&hellip;';"
+            "};"
 
-                        "var boxed_titles = document.querySelectorAll('.boxed h1.boxed_text');"
-                        "var boxed_title_length = 55;"
-                        "for(var i = 0; i < boxed_titles.length; i++){"
-                        "  boxed_titles[i].innerHTML = truncate.apply(boxed_titles[i].innerText, [boxed_title_length, true]);   "
-                        "}"
+            "var boxed_titles = document.querySelectorAll('.boxed h1.boxed_text');"
+            "var boxed_title_length = 55;"
+            "for(var i = 0; i < boxed_titles.length; i++){"
+            "  boxed_titles[i].innerHTML = truncate.apply(boxed_titles[i].innerText, [boxed_title_length, true]);   "
+            "}"
 
-                        "var boxed_descriptions = document.querySelectorAll('.boxed p.boxed_text');"
-                        "var boxed_descriptions_length = 85;"
-                        "for(var i = 0; i < boxed_descriptions.length; i++){"
-                        "  boxed_descriptions[i].innerHTML = truncate.apply(boxed_descriptions[i].innerText, [boxed_descriptions_length, true]);  " 
-                        "}"
-                        )
+            "var boxed_descriptions = document.querySelectorAll('.boxed p.boxed_text');"
+            "var boxed_descriptions_length = 85;"
+            "for(var i = 0; i < boxed_descriptions.length; i++){"
+            "  boxed_descriptions[i].innerHTML = truncate.apply(boxed_descriptions[i].innerText, [boxed_descriptions_length, true]);  " 
+            "}"
+            )
         f = open('index.html','w')
-        f.write(doc.getvalue())
+        f.write(pageHTML)
         f.close()
 
     def generatePagesForProjects(self):


### PR DESCRIPTION
We were relying on a module called yattag which would let you write HTML as python but it was ugly and somewhat non-standard. This pull request switches to using HTML in strings instead, which is also not a perfect solution but seems more straightforwards to maintain because at least there are resources for working with HTML while yattag is its own thing