### PR TITLE
fix utf encoding

### DIFF
--- a/generateHTML.py
+++ b/generateHTML.py
@@ -451,6 +451,7 @@ class GenerateHTML:
                 "</html>")
             
             #Generate and HTML file for the project
+            pageHTML = pageHTML.encode('utf-8')
             f = open(project.projectFile,'w')
             f.write(pageHTML)
             f.close()


### PR DESCRIPTION
We were seeing this error:

Traceback (most recent call last):
  File "buildSite.py", line 9, in <module>
    htmlGenerator.generatePagesForProjects()
  File "/var/www/html/generateHTML.py", line 455, in generatePagesForProjects
    f.write(pageHTML)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xb0' in position 4009: ordinal not in range(128)

The solution was to encode properly using utf =8 rather than just make it a str()