### PR TITLE
Remove the $ sign

### DIFF
--- a/generateHTML.py
+++ b/generateHTML.py
@@ -173,7 +173,7 @@ class GenerateHTML:
             
             try:
                 price = json.loads(project.ROBOTtext)["Price"]
-                projectSection = projectSection + "<div class='bottom-left'>$"+str(price)+"</div>"
+                projectSection = projectSection + "<div class='bottom-left'>"+str(price)+"</div>"
             except Exception as e:
                 pass
             


### PR DESCRIPTION
As mentioned in this forum thread: https://forums.maslowcnc.com/t/bosch-pof-1200-z-axis-kits

Maslow is an international community and so prices should be able to be listed in any currency. The price field is now a string and any value can be put in there