### PR TITLE
Force GitHub user validation before creating repo

### DIFF
--- a/createRepo.py
+++ b/createRepo.py
@@ -57,14 +57,10 @@ if projectName != "none":
         
         time.sleep(3) #This is probably more delay than github needs to create the repo. With no delay at all it worked about half the time
         
-        try:
-            print "Adding GitHub User:"
-            print githubUser
-            print "       "
-            repo.add_to_collaborators(githubUser)
-        except Exception as e:
-            print "Unable to add " + githubUser + " as a collaborator:"
-            print e
+        print "Adding GitHub User:"
+        print githubUser
+        print "       "
+        repo.add_to_collaborators(githubUser)
         
         robotText = (
             '{\n'


### PR DESCRIPTION
We've been seeing some spam bots fill out the form to create a project, but none of them have entered a valid GitHub user name. This PR requires that a valid GitHub user name be entered for the project to be created